### PR TITLE
Fix: Replace NewPipe with nowinandroid sample

### DIFF
--- a/configs/default-patterns.yaml
+++ b/configs/default-patterns.yaml
@@ -781,7 +781,6 @@ projects:
       - 'versionCode\s*=?\s*([0-9]+)'
     samples:
       - https://github.com/signalapp/Signal-Android
-      - https://github.com/TeamNewPipe/NewPipe
       - https://github.com/mozilla-mobile/firefox-android
     priority: 44
     notes: "Android application version from build.gradle"
@@ -797,6 +796,7 @@ projects:
       - https://github.com/JetBrains/compose-multiplatform
       - https://github.com/android/compose-samples
       - https://github.com/cashapp/paparazzi
+      - https://github.com/android/nowinandroid
     priority: 45
     notes: "Android Kotlin Gradle version"
 


### PR DESCRIPTION
## Problem

The `Comprehensive Testing` integration suite fails (`binary failed with exit code 1`) on `TeamNewPipe/NewPipe`. NewPipe now uses Kotlin DSL with a **symbolic version constant**:

```kotlin
// app/build.gradle.kts
versionName = NEWPIPE_VERSION_NAME
// buildSrc/src/main/kotlin/ProjectConfig.kt
const val NEWPIPE_VERSION_NAME = "0.28.8"
```

The regex extractor only matches **literal** version strings, so it can't resolve the `NEWPIPE_VERSION_NAME` reference and reports "no version found in any supported project files". NewPipe was also **miscategorised** under the Groovy `Android - build.gradle` block despite being a `build.gradle.kts` project.

## Fix

Replace it with [`android/nowinandroid`](https://github.com/android/nowinandroid) — Google's maintained Kotlin DSL reference app, which declares a literal `versionName = "0.1.2"` in `app/build.gradle.kts` — and list it under the correct `Android - build.gradle.kts` block.

Verified locally against this config: extracts `Android` / `Gradle (Kotlin)` → `0.1.2`, `success: true`.

## Follow-up

`TeamNewPipe/NewPipe` should be reinstated once the extractor learns to resolve simple `buildSrc` version constants (to be implemented separately).