### PR TITLE
Feat: Resolve Gradle/Kotlin version constants

### DIFF
--- a/configs/default-patterns.yaml
+++ b/configs/default-patterns.yaml
@@ -781,7 +781,6 @@ projects:
       - 'versionCode\s*=?\s*([0-9]+)'
     samples:
       - https://github.com/signalapp/Signal-Android
-      - https://github.com/TeamNewPipe/NewPipe
       - https://github.com/mozilla-mobile/firefox-android
     priority: 44
     notes: "Android application version from build.gradle"
@@ -797,6 +796,7 @@ projects:
       - https://github.com/JetBrains/compose-multiplatform
       - https://github.com/android/compose-samples
       - https://github.com/cashapp/paparazzi
+      - https://github.com/android/nowinandroid
     priority: 45
     notes: "Android Kotlin Gradle version"
 

--- a/configs/default-patterns.yaml
+++ b/configs/default-patterns.yaml
@@ -797,6 +797,7 @@ projects:
       - https://github.com/android/compose-samples
       - https://github.com/cashapp/paparazzi
       - https://github.com/android/nowinandroid
+      - https://github.com/TeamNewPipe/NewPipe
     priority: 45
     notes: "Android Kotlin Gradle version"
 

--- a/internal/extractor/constant_resolver.go
+++ b/internal/extractor/constant_resolver.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// maxConstantScanFiles bounds the number of Kotlin/Gradle files scanned when
+// resolving a version constant, to keep the cost reasonable on large repos.
+const maxConstantScanFiles = 600
+
+// errStopWalk is a sentinel used to halt filepath.Walk early once a match is
+// found (filepath.Walk has no other early-exit mechanism).
+var errStopWalk = errors.New("stop walk")
+
+// resolveVersionConstant handles the common Kotlin/Gradle idiom where the
+// version is assigned from a named constant instead of a literal:
+//
+//	// app/build.gradle.kts
+//	versionName = NEWPIPE_VERSION_NAME
+//	// buildSrc/src/main/kotlin/ProjectConfig.kt
+//	const val NEWPIPE_VERSION_NAME = "0.28.8"
+//
+// The assignment key it looks for (versionName and/or version) is derived from
+// the running project type's own regex patterns, so the resulting project_type
+// label stays consistent with the type that matched. It scans refFile for such
+// a reference and resolves the constant's literal value by searching
+// conventional locations within searchPath (buildSrc, build-logic, the
+// referencing file's directory) before falling back to a bounded walk of the
+// wider tree. It returns the resolved version and a description of the match.
+func (e *VersionExtractor) resolveVersionConstant(refFile, searchPath string,
+	patterns []string) (string, string, error) {
+
+	// Only Gradle build scripts use this assignment idiom.
+	if !isGradleScript(refFile) {
+		return "", "", nil
+	}
+
+	keys := versionAssignmentKeys(patterns)
+	if len(keys) == 0 {
+		return "", "", nil
+	}
+	refRe, err := constRefPattern(keys)
+	if err != nil {
+		return "", "", err
+	}
+
+	content, err := fileReader.ReadFileContent(refFile, true)
+	if err != nil {
+		return "", "", err
+	}
+
+	refs := refRe.FindAllStringSubmatch(stripCommentLines(content), -1)
+	if len(refs) == 0 {
+		return "", "", nil
+	}
+
+	for _, ref := range refs {
+		ident := ref[1]
+		value, defFile := e.lookupConstantValue(ident, searchPath,
+			filepath.Dir(refFile))
+		if value == "" {
+			continue
+		}
+		clean := e.cleanVersion(value)
+		if e.isValidVersion(clean) {
+			matchedBy := fmt.Sprintf("constant %s defined in %s",
+				ident, filepath.Base(defFile))
+			return clean, matchedBy, nil
+		}
+	}
+
+	return "", "", nil
+}
+
+// versionAssignmentKeys inspects a project type's regex patterns and returns
+// the version assignment key(s) they target — "versionName" (Android) and/or
+// "version" (generic Gradle/Kotlin). versionCode and other keys are ignored so
+// that, e.g., a Java/Kotlin type (which targets `version`) does not claim an
+// Android app whose version lives in `versionName`.
+func versionAssignmentKeys(patterns []string) []string {
+	var keys []string
+	seen := map[string]bool{}
+	add := func(k string) {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for _, p := range patterns {
+		switch {
+		case strings.Contains(p, "versionName"):
+			add("versionName")
+		case strings.Contains(p, "versionCode"):
+			// integer code, not a resolvable version name
+		case strings.Contains(p, "version"):
+			add("version")
+		}
+	}
+	return keys
+}
+
+// constRefPattern builds (and caches) a regex matching `<key> = IDENTIFIER` for
+// the given assignment keys, where the right-hand side is a bare constant
+// reference rather than a quoted literal, numeric literal, or function call.
+func constRefPattern(keys []string) (*regexp.Regexp, error) {
+	alt := strings.Join(keys, "|")
+	return getCompiledRegex(
+		`(?m)(?:^|[^A-Za-z0-9_])(?:` + alt + `)[ \t]*=[ \t]*` +
+			`([A-Za-z_][A-Za-z0-9_]*)[ \t]*(?://.*)?$`)
+}
+
+// lookupConstantValue searches the project for a Kotlin constant definition of
+// the form `const val IDENT = "value"` (or `val IDENT = "value"`, optionally
+// typed) and returns its literal value and the file it was found in.
+// Conventional constant locations are searched first; a bounded walk of
+// searchPath is the fallback.
+func (e *VersionExtractor) lookupConstantValue(ident, searchPath,
+	refDir string) (string, string) {
+
+	defRe, err := getCompiledRegex(
+		`(?m)(?:^|[^A-Za-z0-9_])(?:const[ \t]+)?val[ \t]+` +
+			regexp.QuoteMeta(ident) +
+			`[ \t]*(?::[^=\n]+)?=[ \t]*"([^"]+)"`)
+	if err != nil {
+		return "", ""
+	}
+
+	var value, valueFile string
+	scanned := 0
+
+	scan := func(root string) {
+		info, statErr := os.Stat(root)
+		if statErr != nil || !info.IsDir() {
+			return
+		}
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo,
+			werr error) error {
+			if werr != nil {
+				return nil
+			}
+			if fi.IsDir() {
+				if strings.HasPrefix(fi.Name(), ".") {
+					return filepath.SkipDir
+				}
+				for _, skip := range e.skipDirectories {
+					if fi.Name() == skip {
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			if !isKotlinSource(fi.Name()) {
+				return nil
+			}
+			if scanned >= maxConstantScanFiles {
+				return errStopWalk
+			}
+			scanned++
+			fileContent, readErr := fileReader.ReadFileContent(path, true)
+			if readErr != nil {
+				return nil
+			}
+			if m := defRe.FindStringSubmatch(stripCommentLines(fileContent)); len(m) == 2 {
+				value, valueFile = m[1], path
+				return errStopWalk
+			}
+			return nil
+		})
+	}
+
+	for _, root := range []string{
+		filepath.Join(searchPath, "buildSrc"),
+		filepath.Join(searchPath, "build-logic"),
+		refDir,
+		searchPath,
+	} {
+		scan(root)
+		if value != "" || scanned >= maxConstantScanFiles {
+			break
+		}
+	}
+
+	return value, valueFile
+}
+
+// isGradleScript reports whether the file is a Gradle build script where the
+// constant-reference idiom can appear.
+func isGradleScript(name string) bool {
+	return strings.HasSuffix(name, ".gradle.kts") ||
+		strings.HasSuffix(name, ".gradle") ||
+		strings.HasSuffix(name, ".kts")
+}
+
+// isKotlinSource reports whether the file may contain a Kotlin/Gradle constant
+// definition. Only Kotlin sources are scanned: `const val`/`val` is Kotlin
+// syntax, so Groovy `*.gradle` files (which use `def`) would never match and
+// would only consume the scan budget.
+func isKotlinSource(name string) bool {
+	return strings.HasSuffix(name, ".kt") ||
+		strings.HasSuffix(name, ".kts")
+}
+
+// stripCommentLines removes whole-line comments (lines whose first
+// non-whitespace characters are //, /*, or *) before pattern matching, so a
+// commented-out example like `// versionName = SOME_CONST` or a doc snippet
+// like `// const val FOO = "9.9.9"` is not mistaken for a real assignment or
+// definition. Trailing comments after real code (e.g. `versionName = X // c`)
+// are unaffected because such lines do not start with a comment marker.
+func stripCommentLines(content string) string {
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") ||
+			strings.HasPrefix(trimmed, "/*") ||
+			strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/extractor/constant_resolver_test.go
+++ b/internal/extractor/constant_resolver_test.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lfreleng-actions/version-extract-action/internal/config"
+)
+
+// kotlinAndroidConfig returns a config mirroring the real
+// "Android - build.gradle.kts" project type (literal versionName only).
+func kotlinAndroidConfig() *config.Config {
+	return &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:    "Android",
+				Subtype: "Gradle (Kotlin)",
+				File:    "build.gradle.kts",
+				Regex: []string{
+					`versionName\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-\.][a-zA-Z0-9]+)?)"`,
+				},
+				Priority: 1,
+			},
+		},
+	}
+}
+
+// writeFile is a small test helper that creates parent directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestResolveVersionConstantFromBuildSrc reproduces the NewPipe idiom: an
+// app build script that sets versionName from a constant defined in buildSrc.
+func TestResolveVersionConstantFromBuildSrc(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        applicationId = "org.example.app"
+        versionCode = 1013
+        versionName = NEWPIPE_VERSION_NAME
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "src", "main", "kotlin", "ProjectConfig.kt"), `const val NEWPIPE_VERSION_CODE = 1013
+const val NEWPIPE_VERSION_NAME = "0.28.8"`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected successful extraction")
+	}
+	if result.Version != "0.28.8" {
+		t.Errorf("expected version 0.28.8, got %q", result.Version)
+	}
+	if result.VersionSource != "static-constant" {
+		t.Errorf("expected version_source static-constant, got %q", result.VersionSource)
+	}
+	if result.ProjectType != "Android" {
+		t.Errorf("expected Android, got %q", result.ProjectType)
+	}
+}
+
+// TestResolveVersionConstantTypedVal covers a typed `const val NAME: String`.
+func TestResolveVersionConstantTypedVal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "build.gradle.kts"),
+		"version = APP_VERSION\n")
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "Versions.kt"),
+		`const val APP_VERSION: String = "2.5.1"`)
+
+	cfg := &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:     "Kotlin",
+				Subtype:  "Gradle",
+				File:     "build.gradle.kts",
+				Regex:    []string{`version\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?)"`},
+				Priority: 1,
+			},
+		},
+	}
+
+	result, err := New(cfg).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "2.5.1" {
+		t.Errorf("expected version 2.5.1, got %q", result.Version)
+	}
+}
+
+// TestLiteralVersionStillPreferred ensures a literal versionName is used
+// directly and the constant fallback does not interfere.
+func TestLiteralVersionStillPreferred(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        versionName = "1.4.2"
+    }
+}`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "1.4.2" {
+		t.Errorf("expected version 1.4.2, got %q", result.Version)
+	}
+	if result.VersionSource != "static" {
+		t.Errorf("expected version_source static, got %q", result.VersionSource)
+	}
+}
+
+// TestUnresolvedConstantFails ensures a reference with no resolvable definition
+// does not produce a (wrong) version.
+func TestUnresolvedConstantFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        versionName = MISSING_VERSION_CONSTANT
+    }
+}`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err == nil && result != nil && result.Success {
+		t.Errorf("expected no extraction, got version %q", result.Version)
+	}
+}
+
+// TestResolveVersionConstantQualifiedAssignment covers a qualified left-hand
+// side such as `project.version = APP_VERSION` (Copilot review feedback).
+func TestResolveVersionConstantQualifiedAssignment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "build.gradle.kts"),
+		"project.version = APP_VERSION\n")
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "Versions.kt"),
+		`const val APP_VERSION = "3.1.4"`)
+
+	cfg := &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:     "Kotlin",
+				Subtype:  "Gradle",
+				File:     "build.gradle.kts",
+				Regex:    []string{`version\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?)"`},
+				Priority: 1,
+			},
+		},
+	}
+
+	result, err := New(cfg).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "3.1.4" {
+		t.Errorf("expected version 3.1.4, got %q", result.Version)
+	}
+}
+
+// TestResolveVersionConstantSpecificFile covers passing a build script path
+// directly (not its directory), resolving via the discovered project root
+// (Copilot review feedback).
+func TestResolveVersionConstantSpecificFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A root marker so buildSrc is discoverable when walking up from app/.
+	writeFile(t, filepath.Join(tmpDir, "settings.gradle.kts"), "")
+	appScript := filepath.Join(tmpDir, "app", "build.gradle.kts")
+	writeFile(t, appScript, `android {
+    defaultConfig {
+        versionName = NEWPIPE_VERSION_NAME
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "ProjectConfig.kt"),
+		`const val NEWPIPE_VERSION_NAME = "0.28.8"`)
+
+	// Pass the specific file, not the directory.
+	result, err := New(kotlinAndroidConfig()).Extract(appScript)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "0.28.8" {
+		t.Errorf("expected version 0.28.8, got %q", result.Version)
+	}
+	if result.VersionSource != "static-constant" {
+		t.Errorf("expected version_source static-constant, got %q", result.VersionSource)
+	}
+}
+
+// TestResolveVersionConstantIgnoresComments ensures commented-out assignments
+// and definitions are not mistaken for real ones (Copilot review feedback).
+func TestResolveVersionConstantIgnoresComments(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        // versionName = FAKE_VERSION  (example in a comment, must be ignored)
+        versionName = APP_VERSION
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "ProjectConfig.kt"),
+		"// const val FAKE_VERSION = \"9.9.9\"\nconst val APP_VERSION = \"1.2.3\"\n")
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	// Without comment stripping this would wrongly resolve FAKE_VERSION=9.9.9.
+	if result.Version != "1.2.3" {
+		t.Errorf("expected 1.2.3 (commented assignment/definition ignored), got %q", result.Version)
+	}
+}

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -80,7 +80,7 @@ type ExtractResult struct {
 	File          string `json:"file"`
 	MatchedBy     string `json:"matched_by"`
 	Success       bool   `json:"success"`
-	VersionSource string `json:"version_source,omitempty"` // "static" or "dynamic-git-tag"
+	VersionSource string `json:"version_source,omitempty"` // "static", "static-constant", or "dynamic-git-tag"
 	GitTag        string `json:"git_tag,omitempty"`        // Original git tag if dynamic
 }
 
@@ -161,18 +161,64 @@ func (e *VersionExtractor) extractFromSpecificFile(filePath string) (*ExtractRes
 	// If we found a version, use it (already cleaned and validated by extractVersionFromFile)
 	if version != "" {
 		return &ExtractResult{
-			Version:     version,
-			ProjectType: matchingProject.Type,
-			Subtype:     matchingProject.Subtype,
-			File:        filePath,
-			MatchedBy:   matchedRegex,
-			Success:     true,
+			Version:       version,
+			ProjectType:   matchingProject.Type,
+			Subtype:       matchingProject.Subtype,
+			File:          filePath,
+			MatchedBy:     matchedRegex,
+			Success:       true,
+			VersionSource: "static",
+		}, nil
+	}
+
+	// Fallback: the version may be assigned from a named Kotlin/Gradle constant
+	// (e.g. `versionName = NEWPIPE_VERSION_NAME`). Resolve it relative to the
+	// enclosing project root so buildSrc/build-logic definitions are found.
+	root := e.projectRootForFile(filePath)
+	if cv, matchedBy, cerr := e.resolveVersionConstant(filePath, root,
+		matchingProject.Regex); cerr == nil && cv != "" {
+		return &ExtractResult{
+			Version:       cv,
+			ProjectType:   matchingProject.Type,
+			Subtype:       matchingProject.Subtype,
+			File:          filePath,
+			MatchedBy:     matchedBy,
+			Success:       true,
+			VersionSource: "static-constant",
 		}, nil
 	}
 
 	return &ExtractResult{
 		Success: false,
 	}, fmt.Errorf("no valid version found in file: %s", filePath)
+}
+
+// projectRootForFile walks up from a file to find the enclosing project root,
+// identified by a Gradle/VCS marker (settings.gradle[.kts], buildSrc, or
+// .git). The walk is bounded to 8 parent directories; if no marker is found
+// within that limit (or at all) it falls back to the file's own directory, so
+// a build script nested deeper than 8 levels may not resolve its buildSrc
+// constants. This lets constant resolution locate buildSrc definitions when a
+// specific build script (rather than a directory) is passed to Extract.
+func (e *VersionExtractor) projectRootForFile(filePath string) string {
+	dir := filepath.Dir(filePath)
+	current := dir
+	markers := []string{
+		"settings.gradle", "settings.gradle.kts", "buildSrc", ".git",
+	}
+	for i := 0; i < 8; i++ {
+		for _, marker := range markers {
+			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
+				return current
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return dir
 }
 
 // extractFromDirectory handles extraction from a directory (existing behavior)
@@ -283,6 +329,22 @@ func (e *VersionExtractor) tryExtractFromProject(searchPath string,
 				MatchedBy:     matchedRegex,
 				Success:       true,
 				VersionSource: "static",
+			}, nil
+		}
+
+		// Fallback: the version may be assigned from a named Kotlin/Gradle
+		// constant (e.g. `versionName = NEWPIPE_VERSION_NAME`) rather than a
+		// literal. Resolve it from buildSrc and similar locations.
+		if cv, matchedBy, cerr := e.resolveVersionConstant(file,
+			searchPath, project.Regex); cerr == nil && cv != "" {
+			return &ExtractResult{
+				Version:       cv,
+				ProjectType:   project.Type,
+				Subtype:       project.Subtype,
+				File:          file,
+				MatchedBy:     matchedBy,
+				Success:       true,
+				VersionSource: "static-constant",
 			}, nil
 		}
 	}


### PR DESCRIPTION
## What

Adds support for resolving Gradle/Kotlin **version constants**, so projects that assign the version from a named constant (rather than a literal) extract correctly:

```kotlin
// app/build.gradle.kts
versionName = NEWPIPE_VERSION_NAME
// buildSrc/src/main/kotlin/ProjectConfig.kt
const val NEWPIPE_VERSION_NAME = "0.28.8"
```

When the literal regex patterns miss, the extractor now scans the build script for a `versionName`/`version` assigned to a bare identifier and resolves it from `const val IDENT = "…"` definitions in `buildSrc`, `build-logic`, the referencing directory, then a bounded walk of the tree (capped at 600 files).

The assignment key (`versionName` vs `version`) is derived from the **running project type's own regex**, so the result keeps the correct `project_type` label — e.g. an Android app stays `Android` rather than being claimed by the earlier-priority `Java`/`build.gradle.kts` type (which targets `version`).

## Result

`TeamNewPipe/NewPipe` is re-added to the `Android - build.gradle.kts` samples and now extracts:

- `project_type: Android` / `subtype: Gradle (Kotlin)`
- `version: 0.28.8`
- `matched_by: constant NEWPIPE_VERSION_NAME defined in ProjectConfig.kt`
- `version_source: static-constant` (new source)

## Tests / validation

- New `constant_resolver_test.go`: buildSrc resolution, typed `const val`, literal-still-preferred (no regression), unresolved-constant-fails.
- Full unit suite, `go vet`, `gofmt -l`, and `yamllint` all pass; verified end-to-end against a fresh NewPipe clone.
- The fallback only runs when the normal literal patterns find nothing, so existing extractions are unaffected.

## Note

Stacks on #106 (which removed the broken NewPipe entry and added `nowinandroid`). Until #106 merges, this PR's diff includes that one-line config change; it reduces to just this feature once #106 lands. Best merged after #106.