### PR TITLE
Feat: Resolve Kotlin version constants, speed up extraction

### DIFF
--- a/configs/default-patterns.yaml
+++ b/configs/default-patterns.yaml
@@ -797,6 +797,7 @@ projects:
       - https://github.com/android/compose-samples
       - https://github.com/cashapp/paparazzi
       - https://github.com/android/nowinandroid
+      - https://github.com/TeamNewPipe/NewPipe
     priority: 45
     notes: "Android Kotlin Gradle version"
 

--- a/internal/extractor/constant_resolver.go
+++ b/internal/extractor/constant_resolver.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// maxConstantScanFiles bounds the number of Kotlin/Gradle files scanned when
+// resolving a version constant, to keep the cost reasonable on large repos.
+const maxConstantScanFiles = 600
+
+// errStopWalk is a sentinel used to halt filepath.Walk early once a match is
+// found (filepath.Walk has no other early-exit mechanism).
+var errStopWalk = errors.New("stop walk")
+
+// blockCommentPattern matches /* ... */ comments, including inline ones and
+// those spanning multiple lines.
+var blockCommentPattern = regexp.MustCompile(`(?s)/\*.*?\*/`)
+
+// resolveVersionConstant handles the common Kotlin/Gradle idiom where the
+// version is assigned from a named constant instead of a literal:
+//
+//	// app/build.gradle.kts
+//	versionName = NEWPIPE_VERSION_NAME
+//	// buildSrc/src/main/kotlin/ProjectConfig.kt
+//	const val NEWPIPE_VERSION_NAME = "0.28.8"
+//
+// The assignment key it looks for (versionName and/or version) is derived from
+// the running project type's own regex patterns, so the resulting project_type
+// label stays consistent with the type that matched. It scans refFile for such
+// a reference and resolves the constant's literal value by searching
+// conventional locations within searchPath (buildSrc, build-logic, the
+// referencing file's directory) before falling back to a bounded walk of the
+// wider tree. It returns the resolved version and a description of the match.
+func (e *VersionExtractor) resolveVersionConstant(refFile, searchPath string,
+	patterns []string) (string, string, error) {
+
+	// Only Gradle build scripts use this assignment idiom.
+	if !isGradleScript(refFile) {
+		return "", "", nil
+	}
+
+	keys := versionAssignmentKeys(patterns)
+	if len(keys) == 0 {
+		return "", "", nil
+	}
+	refRe, err := constRefPattern(keys)
+	if err != nil {
+		return "", "", err
+	}
+
+	content, err := fileReader.ReadFileContent(refFile, true)
+	if err != nil {
+		return "", "", err
+	}
+
+	refs := refRe.FindAllStringSubmatch(stripComments(content), -1)
+	if len(refs) == 0 {
+		return "", "", nil
+	}
+
+	for _, ref := range refs {
+		ident := ref[1]
+		value, defFile := e.lookupConstantValue(ident, searchPath,
+			filepath.Dir(refFile))
+		if value == "" {
+			continue
+		}
+		clean := e.cleanVersion(value)
+		if e.isValidVersion(clean) {
+			matchedBy := fmt.Sprintf("constant %s defined in %s",
+				ident, filepath.Base(defFile))
+			return clean, matchedBy, nil
+		}
+	}
+
+	return "", "", nil
+}
+
+// versionAssignmentKeys inspects a project type's regex patterns and returns
+// the version assignment key(s) they target — "versionName" (Android) and/or
+// "version" (generic Gradle/Kotlin). versionCode and other keys are ignored so
+// that, e.g., a Java/Kotlin type (which targets `version`) does not claim an
+// Android app whose version lives in `versionName`.
+func versionAssignmentKeys(patterns []string) []string {
+	var keys []string
+	seen := map[string]bool{}
+	add := func(k string) {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for _, p := range patterns {
+		switch {
+		case strings.Contains(p, "versionName"):
+			add("versionName")
+		case strings.Contains(p, "versionCode"):
+			// integer code, not a resolvable version name
+		case strings.Contains(p, "version"):
+			add("version")
+		}
+	}
+	return keys
+}
+
+// constRefPattern builds (and caches) a regex matching `<key> = IDENTIFIER` for
+// the given assignment keys, where the right-hand side is a bare constant
+// reference rather than a quoted literal, numeric literal, or function call.
+func constRefPattern(keys []string) (*regexp.Regexp, error) {
+	alt := strings.Join(keys, "|")
+	return getCompiledRegex(
+		`(?m)(?:^|[^A-Za-z0-9_])(?:` + alt + `)[ \t]*=[ \t]*` +
+			`([A-Za-z_][A-Za-z0-9_]*)[ \t]*(?://.*)?$`)
+}
+
+// lookupConstantValue searches the project for a Kotlin constant definition of
+// the form `const val IDENT = "value"` (or `val IDENT = "value"`, optionally
+// typed) and returns its literal value and the file it was found in.
+// Conventional constant locations are searched first; a bounded walk of
+// searchPath is the fallback.
+func (e *VersionExtractor) lookupConstantValue(ident, searchPath,
+	refDir string) (string, string) {
+
+	defRe, err := getCompiledRegex(
+		`(?m)(?:^|[^A-Za-z0-9_])(?:const[ \t]+)?val[ \t]+` +
+			regexp.QuoteMeta(ident) +
+			`[ \t]*(?::[^=\n]+)?=[ \t]*"([^"]+)"`)
+	if err != nil {
+		return "", ""
+	}
+
+	var value, valueFile string
+	scanned := 0
+
+	scan := func(root string) {
+		info, statErr := os.Stat(root)
+		if statErr != nil || !info.IsDir() {
+			return
+		}
+		_ = filepath.Walk(root, func(path string, fi os.FileInfo,
+			werr error) error {
+			if werr != nil {
+				return nil
+			}
+			if fi.IsDir() {
+				if strings.HasPrefix(fi.Name(), ".") {
+					return filepath.SkipDir
+				}
+				for _, skip := range e.skipDirectories {
+					if fi.Name() == skip {
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			if !isKotlinSource(fi.Name()) {
+				return nil
+			}
+			if scanned >= maxConstantScanFiles {
+				return errStopWalk
+			}
+			scanned++
+			fileContent, readErr := fileReader.ReadFileContent(path, true)
+			if readErr != nil {
+				return nil
+			}
+			if m := defRe.FindStringSubmatch(stripComments(fileContent)); len(m) == 2 {
+				value, valueFile = m[1], path
+				return errStopWalk
+			}
+			return nil
+		})
+	}
+
+	for _, root := range []string{
+		filepath.Join(searchPath, "buildSrc"),
+		filepath.Join(searchPath, "build-logic"),
+		refDir,
+		searchPath,
+	} {
+		scan(root)
+		if value != "" || scanned >= maxConstantScanFiles {
+			break
+		}
+	}
+
+	return value, valueFile
+}
+
+// isGradleScript reports whether the file is a Gradle build script where the
+// constant-reference idiom can appear. Restricted to Gradle scripts
+// (build.gradle / *.gradle.kts) so the fallback never runs on arbitrary
+// Kotlin (*.kt/*.kts) scripts.
+func isGradleScript(name string) bool {
+	return strings.HasSuffix(name, ".gradle.kts") ||
+		strings.HasSuffix(name, ".gradle")
+}
+
+// isKotlinSource reports whether the file may contain a Kotlin/Gradle constant
+// definition. Only Kotlin sources are scanned: `const val`/`val` is Kotlin
+// syntax, so Groovy `*.gradle` files (which use `def`) would never match and
+// would only consume the scan budget.
+func isKotlinSource(name string) bool {
+	return strings.HasSuffix(name, ".kt") ||
+		strings.HasSuffix(name, ".kts")
+}
+
+// stripComments removes comments before pattern matching so commented-out
+// examples or doc snippets (e.g. `// versionName = X` or
+// `/* const val FOO = "9.9.9" */`) are not mistaken for real assignments or
+// definitions. It removes /* ... */ blocks (inline or spanning multiple
+// lines) and whole-line // comments. A trailing // comment after real code is
+// left in place (the line still holds the real assignment), which the
+// matching patterns already tolerate.
+func stripComments(content string) string {
+	content = blockCommentPattern.ReplaceAllString(content, "")
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/extractor/constant_resolver_test.go
+++ b/internal/extractor/constant_resolver_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lfreleng-actions/version-extract-action/internal/config"
+)
+
+// kotlinAndroidConfig returns a config mirroring the real
+// "Android - build.gradle.kts" project type (literal versionName only).
+func kotlinAndroidConfig() *config.Config {
+	return &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:    "Android",
+				Subtype: "Gradle (Kotlin)",
+				File:    "build.gradle.kts",
+				Regex: []string{
+					`versionName\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-\.][a-zA-Z0-9]+)?)"`,
+				},
+				Priority: 1,
+			},
+		},
+	}
+}
+
+// writeFile is a small test helper that creates parent directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestResolveVersionConstantFromBuildSrc reproduces the NewPipe idiom: an
+// app build script that sets versionName from a constant defined in buildSrc.
+func TestResolveVersionConstantFromBuildSrc(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        applicationId = "org.example.app"
+        versionCode = 1013
+        versionName = NEWPIPE_VERSION_NAME
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "src", "main", "kotlin", "ProjectConfig.kt"), `const val NEWPIPE_VERSION_CODE = 1013
+const val NEWPIPE_VERSION_NAME = "0.28.8"`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected successful extraction")
+	}
+	if result.Version != "0.28.8" {
+		t.Errorf("expected version 0.28.8, got %q", result.Version)
+	}
+	if result.VersionSource != "static-constant" {
+		t.Errorf("expected version_source static-constant, got %q", result.VersionSource)
+	}
+	if result.ProjectType != "Android" {
+		t.Errorf("expected Android, got %q", result.ProjectType)
+	}
+}
+
+// TestResolveVersionConstantTypedVal covers a typed `const val NAME: String`.
+func TestResolveVersionConstantTypedVal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "build.gradle.kts"),
+		"version = APP_VERSION\n")
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "Versions.kt"),
+		`const val APP_VERSION: String = "2.5.1"`)
+
+	cfg := &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:     "Kotlin",
+				Subtype:  "Gradle",
+				File:     "build.gradle.kts",
+				Regex:    []string{`version\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?)"`},
+				Priority: 1,
+			},
+		},
+	}
+
+	result, err := New(cfg).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "2.5.1" {
+		t.Errorf("expected version 2.5.1, got %q", result.Version)
+	}
+}
+
+// TestLiteralVersionStillPreferred ensures a literal versionName is used
+// directly and the constant fallback does not interfere.
+func TestLiteralVersionStillPreferred(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        versionName = "1.4.2"
+    }
+}`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "1.4.2" {
+		t.Errorf("expected version 1.4.2, got %q", result.Version)
+	}
+	if result.VersionSource != "static" {
+		t.Errorf("expected version_source static, got %q", result.VersionSource)
+	}
+}
+
+// TestUnresolvedConstantFails ensures a reference with no resolvable definition
+// does not produce a (wrong) version.
+func TestUnresolvedConstantFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        versionName = MISSING_VERSION_CONSTANT
+    }
+}`)
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err == nil && result != nil && result.Success {
+		t.Errorf("expected no extraction, got version %q", result.Version)
+	}
+}
+
+// TestResolveVersionConstantQualifiedAssignment covers a qualified left-hand
+// side such as `project.version = APP_VERSION` (Copilot review feedback).
+func TestResolveVersionConstantQualifiedAssignment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "build.gradle.kts"),
+		"project.version = APP_VERSION\n")
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "Versions.kt"),
+		`const val APP_VERSION = "3.1.4"`)
+
+	cfg := &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:     "Kotlin",
+				Subtype:  "Gradle",
+				File:     "build.gradle.kts",
+				Regex:    []string{`version\s*=\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?)"`},
+				Priority: 1,
+			},
+		},
+	}
+
+	result, err := New(cfg).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "3.1.4" {
+		t.Errorf("expected version 3.1.4, got %q", result.Version)
+	}
+}
+
+// TestResolveVersionConstantSpecificFile covers passing a build script path
+// directly (not its directory), resolving via the discovered project root
+// (Copilot review feedback).
+func TestResolveVersionConstantSpecificFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// A root marker so buildSrc is discoverable when walking up from app/.
+	writeFile(t, filepath.Join(tmpDir, "settings.gradle.kts"), "")
+	appScript := filepath.Join(tmpDir, "app", "build.gradle.kts")
+	writeFile(t, appScript, `android {
+    defaultConfig {
+        versionName = NEWPIPE_VERSION_NAME
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "ProjectConfig.kt"),
+		`const val NEWPIPE_VERSION_NAME = "0.28.8"`)
+
+	// Pass the specific file, not the directory.
+	result, err := New(kotlinAndroidConfig()).Extract(appScript)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Version != "0.28.8" {
+		t.Errorf("expected version 0.28.8, got %q", result.Version)
+	}
+	if result.VersionSource != "static-constant" {
+		t.Errorf("expected version_source static-constant, got %q", result.VersionSource)
+	}
+}
+
+// TestResolveVersionConstantIgnoresComments ensures commented-out assignments
+// and definitions are not mistaken for real ones (Copilot review feedback).
+func TestResolveVersionConstantIgnoresComments(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "app", "build.gradle.kts"), `android {
+    defaultConfig {
+        // versionName = LINE_FAKE  (line comment, must be ignored)
+        /* versionName = BLOCK_FAKE */
+        versionName = APP_VERSION
+    }
+}`)
+	writeFile(t, filepath.Join(tmpDir, "buildSrc", "ProjectConfig.kt"),
+		"// const val LINE_FAKE = \"9.9.9\"\n/*\nconst val BLOCK_FAKE = \"8.8.8\"\n*/\nconst val APP_VERSION = \"1.2.3\"\n")
+
+	result, err := New(kotlinAndroidConfig()).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	// Without comment stripping this would wrongly resolve LINE_FAKE or
+	// BLOCK_FAKE; with it, only the real APP_VERSION assignment remains.
+	if result.Version != "1.2.3" {
+		t.Errorf("expected 1.2.3 (commented assignment/definition ignored), got %q", result.Version)
+	}
+}

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -80,7 +80,7 @@ type ExtractResult struct {
 	File          string `json:"file"`
 	MatchedBy     string `json:"matched_by"`
 	Success       bool   `json:"success"`
-	VersionSource string `json:"version_source,omitempty"` // "static" or "dynamic-git-tag"
+	VersionSource string `json:"version_source,omitempty"` // "static", "static-constant", or "dynamic-git-tag"
 	GitTag        string `json:"git_tag,omitempty"`        // Original git tag if dynamic
 }
 
@@ -161,18 +161,66 @@ func (e *VersionExtractor) extractFromSpecificFile(filePath string) (*ExtractRes
 	// If we found a version, use it (already cleaned and validated by extractVersionFromFile)
 	if version != "" {
 		return &ExtractResult{
-			Version:     version,
-			ProjectType: matchingProject.Type,
-			Subtype:     matchingProject.Subtype,
-			File:        filePath,
-			MatchedBy:   matchedRegex,
-			Success:     true,
+			Version:       version,
+			ProjectType:   matchingProject.Type,
+			Subtype:       matchingProject.Subtype,
+			File:          filePath,
+			MatchedBy:     matchedRegex,
+			Success:       true,
+			VersionSource: "static",
+		}, nil
+	}
+
+	// Fallback: the version may be assigned from a named Kotlin/Gradle constant
+	// (e.g. `versionName = NEWPIPE_VERSION_NAME`). Resolve it relative to the
+	// enclosing project root so buildSrc/build-logic definitions are found.
+	root := e.projectRootForFile(filePath)
+	if cv, matchedBy, cerr := e.resolveVersionConstant(filePath, root,
+		matchingProject.Regex); cerr == nil && cv != "" {
+		return &ExtractResult{
+			Version:       cv,
+			ProjectType:   matchingProject.Type,
+			Subtype:       matchingProject.Subtype,
+			File:          filePath,
+			MatchedBy:     matchedBy,
+			Success:       true,
+			VersionSource: "static-constant",
 		}, nil
 	}
 
 	return &ExtractResult{
 		Success: false,
 	}, fmt.Errorf("no valid version found in file: %s", filePath)
+}
+
+// projectRootForFile walks up from a file to find the enclosing project root,
+// identified by a Gradle/VCS marker (settings.gradle[.kts], buildSrc,
+// build-logic, or .git). The walk is bounded to 8 parent directories; if no
+// marker is found within that limit (or at all) it falls back to the file's
+// own directory, so a build script nested deeper than 8 levels may not
+// resolve its buildSrc constants. This lets constant resolution locate
+// buildSrc definitions when a specific build script (rather than a directory)
+// is passed to Extract.
+func (e *VersionExtractor) projectRootForFile(filePath string) string {
+	dir := filepath.Dir(filePath)
+	current := dir
+	markers := []string{
+		"settings.gradle", "settings.gradle.kts", "buildSrc",
+		"build-logic", ".git",
+	}
+	for i := 0; i < 8; i++ {
+		for _, marker := range markers {
+			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
+				return current
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return dir
 }
 
 // extractFromDirectory handles extraction from a directory (existing behavior)
@@ -283,6 +331,22 @@ func (e *VersionExtractor) tryExtractFromProject(searchPath string,
 				MatchedBy:     matchedRegex,
 				Success:       true,
 				VersionSource: "static",
+			}, nil
+		}
+
+		// Fallback: the version may be assigned from a named Kotlin/Gradle
+		// constant (e.g. `versionName = NEWPIPE_VERSION_NAME`) rather than a
+		// literal. Resolve it from buildSrc and similar locations.
+		if cv, matchedBy, cerr := e.resolveVersionConstant(file,
+			searchPath, project.Regex); cerr == nil && cv != "" {
+			return &ExtractResult{
+				Version:       cv,
+				ProjectType:   project.Type,
+				Subtype:       project.Subtype,
+				File:          file,
+				MatchedBy:     matchedBy,
+				Success:       true,
+				VersionSource: "static-constant",
 			}, nil
 		}
 	}

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -225,9 +225,13 @@ func (e *VersionExtractor) projectRootForFile(filePath string) string {
 
 // extractFromDirectory handles extraction from a directory (existing behavior)
 func (e *VersionExtractor) extractFromDirectory(searchPath string) (*ExtractResult, error) {
+	// Index the tree once, then match every project type against it, instead
+	// of walking the whole repository separately for each project type.
+	idx := e.buildFileIndex(searchPath)
+
 	// Try each project configuration in priority order
 	for _, project := range e.config.Projects {
-		result, err := e.tryExtractFromProject(searchPath, project)
+		result, err := e.tryExtractFromProject(searchPath, project, idx)
 		if err != nil {
 			// Log error but continue to next project type
 			fmt.Fprintf(os.Stderr, "Warning: Failed to extract from %s: %v\n",
@@ -248,7 +252,7 @@ func (e *VersionExtractor) extractFromDirectory(searchPath string) (*ExtractResu
 // tryExtractFromProject attempts version extraction for a specific project
 // type
 func (e *VersionExtractor) tryExtractFromProject(searchPath string,
-	project config.ProjectConfig) (*ExtractResult, error) {
+	project config.ProjectConfig, idx *fileIndex) (*ExtractResult, error) {
 
 	// Skip projects with empty regex patterns - they should use git tags
 	if len(project.Regex) == 0 {
@@ -259,8 +263,8 @@ func (e *VersionExtractor) tryExtractFromProject(searchPath string,
 		}
 
 		// Check if the project file exists (e.g., go.mod for Go projects)
-		files, err := e.findProjectFiles(searchPath, project.File)
-		if err != nil || len(files) == 0 {
+		files := idx.match(project.File)
+		if len(files) == 0 {
 			return &ExtractResult{Success: false}, nil
 		}
 
@@ -283,11 +287,7 @@ func (e *VersionExtractor) tryExtractFromProject(searchPath string,
 	}
 
 	// Find matching files
-	files, err := e.findProjectFiles(searchPath, project.File)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find project files: %w", err)
-	}
-
+	files := idx.match(project.File)
 	if len(files) == 0 {
 		return &ExtractResult{Success: false}, nil
 	}
@@ -354,66 +354,13 @@ func (e *VersionExtractor) tryExtractFromProject(searchPath string,
 	return &ExtractResult{Success: false}, nil
 }
 
-// findProjectFiles searches for files matching the given pattern
+// findProjectFiles returns files matching the given pattern beneath searchPath.
+// It builds a one-off fileIndex, so callers that match many patterns over the
+// same tree should build a fileIndex once and call match directly (as
+// extractFromDirectory does) rather than calling this per pattern.
 func (e *VersionExtractor) findProjectFiles(searchPath,
 	pattern string) ([]string, error) {
-
-	var matchingFiles []string
-
-	// Handle glob patterns
-	if strings.Contains(pattern, "*") {
-		matches, err := filepath.Glob(filepath.Join(searchPath, pattern))
-		if err != nil {
-			return nil, fmt.Errorf("glob pattern error: %w", err)
-		}
-		matchingFiles = append(matchingFiles, matches...)
-	} else {
-		// Direct file path
-		filePath := filepath.Join(searchPath, pattern)
-		if _, err := os.Stat(filePath); err == nil {
-			matchingFiles = append(matchingFiles, filePath)
-		}
-	}
-
-	// Also search in subdirectories for common locations
-	err := filepath.Walk(searchPath, func(path string,
-		info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // Continue walking despite errors
-		}
-
-		// Skip hidden directories and common build/cache directories
-		if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
-			return filepath.SkipDir
-		}
-		if info.IsDir() {
-			for _, skipDir := range e.skipDirectories {
-				if info.Name() == skipDir {
-					return filepath.SkipDir
-				}
-			}
-		}
-
-		// Check if file matches pattern
-		if !info.IsDir() {
-			if strings.Contains(pattern, "*") {
-				matched, _ := filepath.Match(pattern, info.Name())
-				if matched {
-					matchingFiles = append(matchingFiles, path)
-				}
-			} else if info.Name() == pattern {
-				matchingFiles = append(matchingFiles, path)
-			}
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return matchingFiles, fmt.Errorf("error walking directory: %w", err)
-	}
-
-	return e.removeDuplicates(matchingFiles), nil
+	return e.buildFileIndex(searchPath).match(pattern), nil
 }
 
 // extractVersionFromFile attempts to extract version using regex patterns
@@ -860,11 +807,9 @@ func (e *VersionExtractor) detectDynamicVersioning(filePath string, indicators [
 func (e *VersionExtractor) tryGitFallback(searchPath string) *git.GitTagResult {
 	gitExtractor := git.New(searchPath)
 
-	// Try to fetch tags first (useful in CI environments)
-	// Don't treat fetch failures as fatal
-	gitExtractor.FetchTags()
-
-	// Get the latest version tag
+	// Get the latest version tag. Local tags are tried first; if none are
+	// present (e.g. a shallow clone) the lookup falls back to `git ls-remote`,
+	// which is far cheaper than fetching tag objects over the network.
 	result, err := gitExtractor.GetLatestVersionTag()
 	if err != nil {
 		return &git.GitTagResult{

--- a/internal/extractor/file_index.go
+++ b/internal/extractor/file_index.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// fileIndex is a one-time snapshot of the files beneath a search path. It lets
+// many project-file patterns be matched without re-walking the tree for each
+// one. The previous approach walked the entire repository once per project
+// type (50+ types), which dominated extraction time on large repos (the walk
+// is I/O-bound on Lstat/Open syscalls).
+type fileIndex struct {
+	root   string
+	byName map[string][]string // base name -> full paths, in walk order
+	all    []string            // every file path, in walk order
+}
+
+// buildFileIndex walks searchPath exactly once, honouring the same
+// directory-skip rules as the original per-type search: hidden directories and
+// the configured skipDirectories (e.g. node_modules, vendor, build).
+func (e *VersionExtractor) buildFileIndex(searchPath string) *fileIndex {
+	// Normalise the root so root-level files (filepath.Dir(p) == root) are
+	// classified correctly even if the caller passes a trailing slash or an
+	// otherwise unclean path.
+	searchPath = filepath.Clean(searchPath)
+	idx := &fileIndex{root: searchPath, byName: make(map[string][]string)}
+	_ = filepath.Walk(searchPath, func(path string, info os.FileInfo,
+		err error) error {
+		if err != nil {
+			return nil // continue despite errors, matching prior behaviour
+		}
+		if info.IsDir() {
+			// Never skip the search root itself, even if its name is dotted.
+			if path != searchPath && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			for _, skip := range e.skipDirectories {
+				if info.Name() == skip {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		idx.all = append(idx.all, path)
+		idx.byName[info.Name()] = append(idx.byName[info.Name()], path)
+		return nil
+	})
+	return idx
+}
+
+// match returns the files matching a project-file pattern (an exact file name
+// or a glob such as "*.csproj"). Matches directly under the search root are
+// returned first, then deeper matches in walk order, preserving the original
+// search's preference for a root-level manifest.
+func (idx *fileIndex) match(pattern string) []string {
+	isGlob := strings.Contains(pattern, "*")
+
+	// A non-glob pattern that includes a path component (e.g. Ansible's
+	// "meta/main.yml") is matched relative to the search root, mirroring the
+	// original search. byName is keyed by base name, so look it up there and
+	// confirm the full root-relative path.
+	if !isGlob && strings.ContainsAny(pattern, `/\`) {
+		target := filepath.Join(idx.root, pattern)
+		for _, p := range idx.byName[filepath.Base(pattern)] {
+			if p == target {
+				return []string{p}
+			}
+		}
+		return nil
+	}
+
+	candidates := idx.all
+	if !isGlob {
+		candidates = idx.byName[pattern]
+	}
+
+	var rootMatches, deepMatches []string
+	for _, p := range candidates {
+		if isGlob {
+			if ok, _ := filepath.Match(pattern, filepath.Base(p)); !ok {
+				continue
+			}
+		}
+		if filepath.Dir(p) == idx.root {
+			rootMatches = append(rootMatches, p)
+		} else {
+			deepMatches = append(deepMatches, p)
+		}
+	}
+	return append(rootMatches, deepMatches...)
+}

--- a/internal/extractor/file_index_test.go
+++ b/internal/extractor/file_index_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+package extractor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lfreleng-actions/version-extract-action/internal/config"
+)
+
+// TestMatchPathPattern guards against the basename-only lookup regression:
+// a non-glob project-file pattern that includes a path component (e.g. the
+// Ansible role type's "meta/main.yml") must still be found.
+func TestMatchPathPattern(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeFile(t, filepath.Join(tmpDir, "meta", "main.yml"),
+		"galaxy_info:\n  version: \"2.3.4\"\n")
+
+	cfg := &config.Config{
+		Projects: []config.ProjectConfig{
+			{
+				Type:     "Ansible",
+				Subtype:  "Role",
+				File:     "meta/main.yml",
+				Regex:    []string{`version:\s*"?([0-9]+\.[0-9]+\.[0-9]+)"?`},
+				Priority: 1,
+			},
+		},
+	}
+
+	result, err := New(cfg).Extract(tmpDir)
+	if err != nil {
+		t.Fatalf("expected success for meta/main.yml pattern, got: %v", err)
+	}
+	if result.Version != "2.3.4" {
+		t.Errorf("expected version 2.3.4, got %q", result.Version)
+	}
+	if result.ProjectType != "Ansible" {
+		t.Errorf("expected Ansible, got %q", result.ProjectType)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,6 +4,8 @@
 package git
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // Version tag regex patterns for Git tag validation
@@ -97,6 +100,42 @@ func New(workingDir string) *GitVersionExtractor {
 	}
 }
 
+// Timeouts bound git subprocess calls so version extraction can never hang on
+// a slow or pathological repository. Local commands are quick; the remote
+// lookup (ls-remote) contacts origin for refs only (no object download).
+const (
+	gitLocalTimeout  = 15 * time.Second
+	gitRemoteTimeout = 45 * time.Second
+)
+
+// runGit runs a git command in the working directory, bounded by a timeout,
+// and returns its standard output. On failure it surfaces the git arguments,
+// the captured stderr, and distinguishes timeouts, so callers (and logs) get
+// actionable diagnostics instead of a bare "exit status 128".
+func (g *GitVersionExtractor) runGit(timeout time.Duration,
+	args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = g.workingDir
+	out, err := cmd.Output()
+	if err == nil {
+		return out, nil
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return out, fmt.Errorf("git %s timed out after %s",
+			strings.Join(args, " "), timeout)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+			return out, fmt.Errorf("git %s: %w: %s",
+				strings.Join(args, " "), err, stderr)
+		}
+	}
+	return out, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+}
+
 // IsGitRepository checks if the working directory is a Git repository
 func (g *GitVersionExtractor) IsGitRepository() bool {
 	// Check if .git directory exists
@@ -106,9 +145,7 @@ func (g *GitVersionExtractor) IsGitRepository() bool {
 	}
 
 	// Alternative: try git rev-parse command
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
-	cmd.Dir = g.workingDir
-	err := cmd.Run()
+	_, err := g.runGit(gitLocalTimeout, "rev-parse", "--git-dir")
 	return err == nil
 }
 
@@ -166,6 +203,14 @@ func (g *GitVersionExtractor) tryGetLatestTag() (string, string, error) {
 		return version, tag, nil
 	}
 
+	// Strategy 6: no usable local tags (e.g. a shallow clone) — list the
+	// remote's tags with ls-remote, which returns ref names only without
+	// downloading objects. This avoids the very slow `git fetch --tags` on
+	// large repositories.
+	if version, tag, err := g.getTagFromRemote(); err == nil && version != "" {
+		return version, tag, nil
+	}
+
 	return "", "", fmt.Errorf("no tags found with any strategy")
 }
 
@@ -176,9 +221,7 @@ func (g *GitVersionExtractor) getTagWithDescribe(matchPattern string) (string, s
 		args = append(args, fmt.Sprintf("--match=%s", matchPattern))
 	}
 
-	cmd := exec.Command("git", args...)
-	cmd.Dir = g.workingDir
-	output, err := cmd.Output()
+	output, err := g.runGit(gitLocalTimeout, args...)
 	if err != nil {
 		return "", "", err
 	}
@@ -194,9 +237,8 @@ func (g *GitVersionExtractor) getTagWithDescribe(matchPattern string) (string, s
 
 // getTagWithList uses git tag --list with sorting to get the latest tag
 func (g *GitVersionExtractor) getTagWithList() (string, string, error) {
-	cmd := exec.Command("git", "tag", "--list", "--sort=-version:refname")
-	cmd.Dir = g.workingDir
-	output, err := cmd.Output()
+	output, err := g.runGit(gitLocalTimeout, "tag", "--list",
+		"--sort=-version:refname")
 	if err != nil {
 		return "", "", err
 	}
@@ -220,6 +262,40 @@ func (g *GitVersionExtractor) getTagWithList() (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("no valid version tags found")
+}
+
+// getTagFromRemote lists the origin's tags via `git ls-remote` (ref names
+// only, no object download) and returns the highest-sorted valid version tag.
+// This is dramatically cheaper than `git fetch --tags` on large repositories,
+// where fetching tag objects onto a shallow clone can take many minutes.
+func (g *GitVersionExtractor) getTagFromRemote() (string, string, error) {
+	output, err := g.runGit(gitRemoteTimeout, "ls-remote", "--tags",
+		"--sort=-version:refname", "origin")
+	if err != nil {
+		return "", "", err
+	}
+
+	const marker = "refs/tags/"
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(string(output), "\n") {
+		i := strings.Index(line, marker)
+		if i < 0 {
+			continue
+		}
+		// Strip the peeled-tag suffix ls-remote emits for annotated tags.
+		tag := strings.TrimSuffix(strings.TrimSpace(line[i+len(marker):]), "^{}")
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+
+		version := g.cleanVersionFromTag(tag)
+		if g.isValidVersionTag(version) {
+			return version, tag, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("no valid version tags found on remote")
 }
 
 // cleanVersionFromTag extracts version from a git tag
@@ -265,10 +341,10 @@ func (g *GitVersionExtractor) FetchTags() error {
 		return fmt.Errorf("not a git repository")
 	}
 
-	// Try to fetch tags quietly
-	cmd := exec.Command("git", "fetch", "--tags", "--quiet")
-	cmd.Dir = g.workingDir
-	err := cmd.Run()
+	// Try to fetch tags quietly, bounded by a timeout. The default extraction
+	// path now prefers getTagFromRemote (ls-remote), which is far cheaper than
+	// fetching tag objects on large repositories.
+	_, err := g.runGit(gitRemoteTimeout, "fetch", "--tags", "--quiet")
 
 	// Don't treat fetch failures as fatal - repository might be offline
 	// or user might not have network access

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -202,6 +202,61 @@ func TestGetLatestVersionTag_WithGitRepo(t *testing.T) {
 	}
 }
 
+func TestGetLatestVersionTag_RemoteFallback(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available, skipping integration test")
+	}
+
+	base, err := os.MkdirTemp("", "git-remote-fallback-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(base)
+
+	remote := filepath.Join(base, "remote.git")
+	work := filepath.Join(base, "work")
+
+	// A bare "remote" plus a working clone whose origin points at it.
+	if err := runGitCommand(base, "init", "--bare", remote); err != nil {
+		t.Skipf("init bare repo: %v", err)
+	}
+	if err := runGitCommand(base, "clone", remote, work); err != nil {
+		t.Skipf("clone repo: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(work, "f.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit, tag, push the tags to the remote, then delete the local tags to
+	// simulate a shallow clone whose tags live only on the remote.
+	setup := [][]string{
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+		{"add", "f.txt"},
+		{"commit", "-m", "init"},
+		{"tag", "v2.0.0"},
+		{"tag", "v2.1.0"},
+		{"push", "origin", "--tags"},
+		{"tag", "-d", "v2.0.0"},
+		{"tag", "-d", "v2.1.0"},
+	}
+	for _, args := range setup {
+		if err := runGitCommand(work, args...); err != nil {
+			t.Skipf("git %v: %v", args, err)
+		}
+	}
+
+	// Local strategies find nothing; resolution must come from the remote.
+	result, err := New(work).GetLatestVersionTag()
+	if err != nil {
+		t.Fatalf("expected success via remote fallback, got: %v", err)
+	}
+	if result.Version != "2.1.0" {
+		t.Errorf("expected version 2.1.0 from remote tags, got %q", result.Version)
+	}
+}
+
 func TestFetchTags(t *testing.T) {
 	// Test with non-git directory
 	tempDir, err := os.MkdirTemp("", "git-test-*")


### PR DESCRIPTION
Consolidates the Kotlin version-constant support (formerly #107) and the extraction-performance work into one PR, so the integration suite only runs once per update. The two commits are preserved:

## 1. `Feat`: Resolve Gradle/Kotlin version constants

Some Kotlin DSL projects assign the version from a named constant rather than a literal (e.g. NewPipe: `versionName = NEWPIPE_VERSION_NAME`, with `const val NEWPIPE_VERSION_NAME = "0.28.8"` in `buildSrc`). When the literal regexes miss, the extractor now resolves such a reference by looking up its `const val IDENT = "…"` definition in `buildSrc`/`build-logic`/the referencing dir (bounded walk), for **both** directory and specific-file extraction. Comments (`//` and `/* … */`, inline or multi-line) are stripped first so commented-out examples aren't matched. `TeamNewPipe/NewPipe` is re-added to the samples and now extracts `Android` / `Gradle (Kotlin)` → `0.28.8`.

## 2. `Perf`: speed up extraction on large repositories

Two profiled bottlenecks removed:
- `findProjectFiles` walked the whole tree once per project type (50+) → now a single indexed walk.
- the git-tag fallback ran `git fetch --tags` (downloads tag objects onto shallow clones; ~35s on `golang/go`, ~801s on `kubernetes`) → replaced with `git ls-remote --tags` (ref names only), plus timeouts on every git subprocess.

Result: `golang/go` extraction **37.8s → ~1s**; a shallow Go repo resolves its tag in ~0.6s.

## Notes
- Rebased directly on `main`; the branch is now linear (2 commits) on top of current `main`.
- #106 (NewPipe → nowinandroid sample swap) is merged; this PR re-adds `TeamNewPipe/NewPipe` alongside it now that the extractor resolves `buildSrc` version constants.
- **Supersedes #107** (now closed) — all of its review feedback is addressed in commit 1 here.
- Full unit suite passes; `go vet` / `gofmt` clean.