### PR TITLE
Fix: resolve Zizmor template-injection findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -86,17 +86,25 @@ runs:
     - name: "Extract project version"
       id: extract
       shell: bash
+      env:
+        INPUT_PATH: "${{ inputs.path }}"
+        INPUT_CONFIG: "${{ inputs.config }}"
+        INPUT_FORMAT: "${{ inputs.format }}"
+        INPUT_VERBOSE: "${{ inputs.verbose }}"
+        INPUT_FAIL_ON_ERROR: "${{ inputs.fail-on-error }}"
+        INPUT_JSON_FORMAT: "${{ inputs.json_format }}"
+        INPUT_DYNAMIC_FALLBACK: "${{ inputs.dynamic-fallback }}"
       run: |
         cd "${{ github.action_path }}"
 
         # Set up parameters
-        SEARCH_PATH="${{ inputs.path }}"
-        CONFIG_PATH="${{ inputs.config }}"
-        FORMAT="${{ inputs.format }}"
-        VERBOSE="${{ inputs.verbose }}"
-        FAIL_ON_ERROR="${{ inputs.fail-on-error }}"
-        JSON_FORMAT="${{ inputs.json_format }}"
-        DYNAMIC_FALLBACK="${{ inputs.dynamic-fallback }}"
+        SEARCH_PATH="$INPUT_PATH"
+        CONFIG_PATH="$INPUT_CONFIG"
+        FORMAT="$INPUT_FORMAT"
+        VERBOSE="$INPUT_VERBOSE"
+        FAIL_ON_ERROR="$INPUT_FAIL_ON_ERROR"
+        JSON_FORMAT="$INPUT_JSON_FORMAT"
+        DYNAMIC_FALLBACK="$INPUT_DYNAMIC_FALLBACK"
 
         # Build command arguments using array
         ARGS=("--path=${SEARCH_PATH}" "--format=json")


### PR DESCRIPTION
## Summary

Resolves all 7 medium+ findings reported by the org-wide Zizmor audit
for this repository (7 `template-injection`).

## Changes

Route the seven inputs consumed by the `Extract project version` step
(`path`, `config`, `format`, `verbose`, `fail-on-error`, `json_format`,
`dynamic-fallback`) through the step `env:` block as `INPUT_*`
variables, and assign the existing shell variables (`SEARCH_PATH`,
`CONFIG_PATH`, …) from those quoted environment variables instead of
interpolating `${{ inputs.* }}` directly into the `run:` body. The
downstream argument array and extraction logic are unchanged.

Behaviour is preserved. Verified with `zizmor --persona regular
--min-severity medium` reporting 0 findings.