### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -231,25 +231,30 @@ jobs:
           echo 'Validating action outputs...'
 
           # Check JavaScript results
-          if [[ "${{ steps.test-js.outputs.success }}" != "true" ]]; then
+          if [[ "${STEPS_TEST_JS_OUTPUTS_SUCCESS}" != "true" ]]; then
             echo '❌ JavaScript action test failed'
             exit 1
           fi
 
-          if [[ "${{ steps.test-js.outputs.version }}" != "1.2.3" ]]; then
+          if [[ "${STEPS_TEST_JS_OUTPUTS_VERSION}" != "1.2.3" ]]; then
             echo "❌ JavaScript version mismatch: expected 1.2.3," \
-              "got ${{ steps.test-js.outputs.version }}"
+              "got ${STEPS_TEST_JS_OUTPUTS_VERSION}"
             exit 1
           fi
 
-          if [[ "${{ steps.test-js.outputs.project-type }}" != \
+          if [[ "${STEPS_TEST_JS_OUTPUTS_PROJECT_TYPE}" != \
             "JavaScript" ]]; then
             echo "❌ JavaScript project type mismatch: expected" \
-              "JavaScript, got ${{ steps.test-js.outputs.project-type }}"
+              "JavaScript, got ${STEPS_TEST_JS_OUTPUTS_PROJECT_TYPE}"
             exit 1
           fi
 
           echo '✅ Action tests passed'
+        env:
+          STEPS_TEST_JS_OUTPUTS_SUCCESS: ${{ steps.test-js.outputs.success }}
+          STEPS_TEST_JS_OUTPUTS_VERSION: ${{ steps.test-js.outputs.version }}
+          # yamllint disable-line rule:line-length
+          STEPS_TEST_JS_OUTPUTS_PROJECT_TYPE: ${{ steps.test-js.outputs.project-type }}
 
       # Phase 7: Error Handling Tests
       - name: 'Error Handling Tests'


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
